### PR TITLE
fix some euler angle conversion issues

### DIFF
--- a/geometry/quaternion.py
+++ b/geometry/quaternion.py
@@ -131,7 +131,7 @@ class Quaternion():
     def body_rotate(self, rate: Point):
         return (self * Quaternion.from_axis_angle(rate)).norm()
 
-    def _to_euler(self):
+    def to_euler(self):
         roll = atan2(
             2 * (self.w * self.x + self.y * self.z),
             1 - 2 * (self.x * self.x + self.y * self.y)
@@ -150,31 +150,31 @@ class Quaternion():
 
         return Point(roll, pitch, yaw)
 
-    def to_euler(self):
-        # https://www.euclideanspace.com/maths/geometry/rotations/conversions/quaternionToEuler/
-        test = self.x*self.y + self.z*self.w
-        if (test > 0.499):  # { // singularity at north pole
-            return Point(
-                0.0,
-                np.pi/2,
-                2 * np.arctan2(self.x, self.w)
-            )
-        elif (test < -0.499):  # { // singularity at south pole
-            return Point(
-                0.0,
-                - np.pi/2,
-                -2 * np.arctan2(self.x, self.w)
-            )
-        sqw = self.w**2
-        sqx = self.x**2
-        sqy = self.y**2
-        sqz = self.z**2
-        unit = sqx + sqy + sqz + sqw
-        return Point(
-            np.arctan2(2*self.x*self.w-2*self.y*self.z, 1 - 2*sqx - 2*sqz),
-            np.arcsin(2*test/unit),
-            np.arctan2(2*self.y*self.w-2*self.x*self.z, 1 - 2*sqy - 2*sqz)
-        )
+    # def to_euler(self):
+    #     # https://www.euclideanspace.com/maths/geometry/rotations/conversions/quaternionToEuler/
+    #     test = self.x*self.y + self.z*self.w
+    #     if (test > 0.499):  # { // singularity at north pole
+    #         return Point(
+    #             0.0,
+    #             np.pi/2,
+    #             2 * np.arctan2(self.x, self.w)
+    #         )
+    #     elif (test < -0.499):  # { // singularity at south pole
+    #         return Point(
+    #             0.0,
+    #             - np.pi/2,
+    #             -2 * np.arctan2(self.x, self.w)
+    #         )
+    #     sqw = self.w**2
+    #     sqx = self.x**2
+    #     sqy = self.y**2
+    #     sqz = self.z**2
+    #     unit = sqx + sqy + sqz + sqw
+    #     return Point(
+    #         np.arctan2(2*self.x*self.w-2*self.y*self.z, 1 - 2*sqx - 2*sqz),
+    #         np.arcsin(2*test/unit),
+    #         np.arctan2(2*self.y*self.w-2*self.x*self.z, 1 - 2*sqy - 2*sqz)
+    #     )
 
     def to_rotation_matrix(self):
         """http://en.wikipedia.org/wiki/Quaternions_and_spatial_rotation

--- a/geometry/quaternion.py
+++ b/geometry/quaternion.py
@@ -82,6 +82,7 @@ class Quaternion():
 
     @staticmethod
     def from_euler(eul: Point):
+        # xyz-fixed Euler angle convention: matches ArduPilot AP_Math/Quaternion::from_euler
         half = eul * 0.5
         c = half.cosines
         s = half.sines
@@ -132,6 +133,7 @@ class Quaternion():
         return (self * Quaternion.from_axis_angle(rate)).norm()
 
     def to_euler(self):
+        # xyz-fixed Euler angle convention: matches ArduPilot AP_Math/Quaternion::to_euler
         roll = atan2(
             2 * (self.w * self.x + self.y * self.z),
             1 - 2 * (self.x * self.x + self.y * self.y)

--- a/tests/test_quaternion.py
+++ b/tests/test_quaternion.py
@@ -20,12 +20,10 @@ class TestQuaternion(unittest.TestCase):
 
         res = np.apply_along_axis(test_func,axis=1, arr=parr)
 
-        # scipy this seems to be producing data with qx and qz swapped, or something else is wrong here!
-        spy = R.from_euler('ZYX', parr).as_quat() 
+        # 'xyz' specifies xyz-fixed Euler angles, as used in ArduPilot
+        spy = R.from_euler('xyz', parr).as_quat()
         spout = spy.copy()
-        spout[:,0] = spy[:,2]
-        spout[:,2] = spy[:,0]
-        
+
         np.testing.assert_array_almost_equal(
             res,
             spout

--- a/tests/test_quaternion.py
+++ b/tests/test_quaternion.py
@@ -29,6 +29,17 @@ class TestQuaternion(unittest.TestCase):
             spout
         )
 
+    def test_to_euler(self):
+        qarr = np.random.random((500, 4))
+        for i in range(0,len(qarr)):
+            q = Quaternion(*qarr[i,:]).norm()
+            sR = R.from_quat(q.xyzw)
+            np.testing.assert_array_almost_equal(
+                np.array(tuple(q.to_euler())),
+                sR.as_euler("xyz")
+            )
+            
+
     def test_from_rotation_matrix(self):
 
         rmats = [

--- a/tests/test_quaternions.py
+++ b/tests/test_quaternions.py
@@ -94,10 +94,8 @@ class TestQuaternions(unittest.TestCase):
 
     def test_from_euler(self):
         
-        spy = R.from_euler('ZYX', tps.data).as_quat()
+        spy = R.from_euler('xyz', tps.data).as_quat()
         spout = spy.copy()
-        spout[:, 0] = spy[:, 2]
-        spout[:, 2] = spy[:, 0]
         np.testing.assert_array_almost_equal(
             Quaternions.from_euler(tps).xyzw,
             spout
@@ -109,7 +107,7 @@ class TestQuaternions(unittest.TestCase):
 
         np.testing.assert_array_almost_equal(
             qs.to_euler().data,
-            R.from_quat(qs.xyzw).as_euler("ZYX")
+            R.from_quat(qs.xyzw).as_euler("xyz")
         )
 
     def test_to_from_euler(self):


### PR DESCRIPTION
XYZ implies intrinsic rotations, but lower case xyz implies extrinsic (i.e. fixed) as used in ardupilot